### PR TITLE
Set split cookie on all subdomains

### DIFF
--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -34,7 +34,7 @@ module Split
       end
 
       def default_options
-        { expires: @expires, path: '/' }
+        { expires: @expires, path: '/', domain: :all }
       end
 
       def hash


### PR DESCRIPTION
We want to share a user's experiment data across subdomains. This way, a user can maintain experiment assignments while navigating through different parts of Flexport (public app->client app, etc.)

![image](https://user-images.githubusercontent.com/921574/41398651-da18de0e-6f6c-11e8-99d0-9b5a1dc7afaf.png)
