### PR TITLE
Manually parse domain (without subdomains) to set on cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 > 📈 The Rack Based A/B testing framework http://libraries.io/rubygems/split
 
+##
+This is a Flexport fork of Split 3.2.0 (a split off of split, if you will) that shares a single cookie between different subdomains for a user when using the cookie adapter for experiment persistence.
+
+##
 Split is a rack based A/B testing framework designed to work with Rails, Sinatra or any other rack based app.
 
 Split is heavily inspired by the [Abingo](https://github.com/ryanb/abingo) and [Vanity](https://github.com/assaf/vanity) Rails A/B testing plugins and [Resque](https://github.com/resque/resque) in its use of Redis.

--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -33,8 +33,25 @@ module Split
         @response.set_cookie :split.to_s, default_options.merge(value: JSON.generate(value))
       end
 
+      # Taken from Rails ActionDispatch::Cookies
+      # https://github.com/rails/rails/blob/91ae6531976d0d2e7690bde0c1d5e6cc651f2578/actionpack/lib/action_dispatch/middleware/cookies.rb#L373
+      def domain_from_host
+        domain_regexp = /[^.]*\.([^.]*|..\...|...\...)$/
+        host = @request.host
+        domain = if (host !~ /^[\d.]+$/) && (host =~ domain_regexp)
+          ".#{$&}"
+        end
+        domain
+      end
+
       def default_options
-        { expires: @expires, path: '/', domain: :all }
+        options_base = { expires: @expires, path: '/' }
+        explicit_domain = domain_from_host
+        if explicit_domain.present?
+          options_base.merge({domain: explicit_domain})
+        else
+          options_base
+        end
       end
 
       def hash


### PR DESCRIPTION
This PR uses the logic from `ActionDispatch::Cookies` to parse the desired domain we want for the cookie we set.

The existing attempt to do this (https://github.com/flexport/split/pull/1) made the incorrect assumption that we were setting cookie options with the `ActionDispatch::Cookies` API, which does the parsing work for you automatically [if you specify `domain: :all`](https://github.com/rails/rails/blob/91ae6531976d0d2e7690bde0c1d5e6cc651f2578/actionpack/lib/action_dispatch/middleware/cookies.rb#L367). In reality, we're setting options using `ActionDispatch::Response`'s `set_cookie`, which does [no such magic mapping](https://github.com/rack/rack/blob/7420be230f73ed350fb0aea612d0ea98cb451778/lib/rack/utils.rb#L223). We don't have access to the corresponding `ActionDispatch::Cookies` object (`cookies` is a private method on `ActionController::Base` and I didn't want to hack around it) so we do the parsing ourselves.

Tested this locally end-to-end by pointing Gemfile to local dir. Domain is set correctly on cookie to not include the `www` part of `www.flexport.xyz`:
![image](https://user-images.githubusercontent.com/921574/41428905-51fdcdc8-6fc0-11e8-8806-3be23fe5b534.png)
